### PR TITLE
Created DeadReckoningService with functioning Step Detection

### DIFF
--- a/DeadCrumbs/app/src/main/AndroidManifest.xml
+++ b/DeadCrumbs/app/src/main/AndroidManifest.xml
@@ -54,11 +54,9 @@
             android:label="@string/title_activity_maps" />
 
         <service
-            android:name=".ui.BluetoothService"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+            android:name=".ui.BluetoothService"/>
         <service
-            android:name=".ui.DeadReckoningService"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar"/>
+            android:name=".ui.DeadReckoningService"/>
     </application>
 
 </manifest>

--- a/DeadCrumbs/app/src/main/AndroidManifest.xml
+++ b/DeadCrumbs/app/src/main/AndroidManifest.xml
@@ -56,6 +56,9 @@
         <service
             android:name=".ui.BluetoothService"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+        <service
+            android:name=".ui.DeadReckoningService"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"/>
     </application>
 
 </manifest>

--- a/DeadCrumbs/app/src/main/java/dead/crumbs/ui/DeadReckoningService.kt
+++ b/DeadCrumbs/app/src/main/java/dead/crumbs/ui/DeadReckoningService.kt
@@ -22,6 +22,7 @@ class DeadReckoningService : Service(), SensorEventListener{
         sensorManager = getSystemService(Context.SENSOR_SERVICE) as SensorManager
         stepCounterSensor = sensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER)
 
+        //TODO: Consider SENSOR_DELAY_FASTEST
         sensorManager.registerListener(this, stepCounterSensor, SensorManager.SENSOR_DELAY_NORMAL)
 
     }

--- a/DeadCrumbs/app/src/main/java/dead/crumbs/ui/DeadReckoningService.kt
+++ b/DeadCrumbs/app/src/main/java/dead/crumbs/ui/DeadReckoningService.kt
@@ -1,0 +1,73 @@
+package dead.crumbs.ui
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.util.Log
+import android.app.Service
+import android.content.Intent
+import android.os.Binder
+import android.os.IBinder
+
+class DeadReckoningService : Service(), SensorEventListener{
+
+    private lateinit var sensorManager: SensorManager
+    private var stepCounterSensor: Sensor? = null
+
+    override fun onCreate() {
+        super.onCreate()
+
+        sensorManager = getSystemService(Context.SENSOR_SERVICE) as SensorManager
+        stepCounterSensor = sensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER)
+
+        sensorManager.registerListener(this, stepCounterSensor, SensorManager.SENSOR_DELAY_NORMAL)
+
+    }
+
+    //----------Binding--------------
+    // Binder given to clients
+    private val binder = LocalBinder()
+
+    /**
+     * Class used for the client Binder.  Because we know this service always
+     * runs in the same process as its clients, we don't need to deal with IPC.
+     */
+
+    inner class LocalBinder : Binder(){
+        // Return this instance of LocalService so clients can call public methods
+        fun getService(): DeadReckoningService = this@DeadReckoningService
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return binder
+    }
+
+    private var stepCounterInitial : Int = 0
+    private var stepCounter : Int = 0
+
+    /* This is called whenever this class (SensorEventListener) detects a new sensor value
+     * from a sensor it is listening to (registerListener) */
+    override fun onSensorChanged(event: SensorEvent) {
+        if (event.sensor.type == Sensor.TYPE_STEP_COUNTER){
+            val sensorValue = event.values[0]
+            // Set initial count value upon first reading
+            if (stepCounterInitial < 1)
+                stepCounterInitial = sensorValue.toInt()
+            // Update counter with #steps taken since initial value
+            stepCounter = sensorValue.toInt() - stepCounterInitial
+
+            //TODO: Find out how and where to pass value on to
+
+            // See LogCat in Android Studio, make sure Verbose is selected
+            // and then search for stepCounter
+            Log.d("stepCounter: ", stepCounter.toString())
+        }
+    }
+
+    override fun onAccuracyChanged(p0: Sensor?, p1: Int) {
+        // Do nothing
+    }
+
+}

--- a/DeadCrumbs/app/src/main/java/dead/crumbs/ui/MainActivity.kt
+++ b/DeadCrumbs/app/src/main/java/dead/crumbs/ui/MainActivity.kt
@@ -78,7 +78,6 @@ class MainActivity : AppCompatActivity() {
     //------------Dead Reckoning-------------//
 
     private lateinit var drService: DeadReckoningService
-    private var drBound: Boolean = false
 
     private fun startDeadReckoning(){
         val intent = Intent(this, DeadReckoningService::class.java)
@@ -97,11 +96,10 @@ class MainActivity : AppCompatActivity() {
             // We've bound to DeadReckoningService, cast the IBinder and get LocalService instance
             val drBinder = service as DeadReckoningService.LocalBinder
             drService = drBinder.getService()
-            drBound = true
         }
 
         override fun onServiceDisconnected(arg0: ComponentName) {
-            drBound = false
+            // Do nothing
         }
     }
 


### PR DESCRIPTION
Also bound the new service to mainactivity.

The idea is that the rest of the dead reckoning code can be placed in this new service and easily use the step counter.

For reviewers:
When running this app, it will automatically run the Dead Reckoning Service.
- Check out the Logcat in android studio and search for "stepCounter".
- Then simulate steps by shaking your phone (or computer with emulator for hardcore reviewers) up and down, and see the Logcat printing out the steps counted.

The code in DeadReckoningService should be mostly readable and easy to review (apart from binding, but we can let Kris review that part).