### PR TITLE
Feature change map start location and rotation issue

### DIFF
--- a/DeadCrumbs/app/src/main/java/dead/crumbs/ui/MapsViewModel.kt
+++ b/DeadCrumbs/app/src/main/java/dead/crumbs/ui/MapsViewModel.kt
@@ -45,7 +45,17 @@ class MapsViewModel (private val locationRepository: LocationRepository,
             Log.i("MapDebug", "Initializing map")
             map = googleMap
             addMarkers(context, activity)
-            map.animateCamera(CameraUpdateFactory.newLatLngZoom(LatLng(57.041480, 9.935950), 14f))
+            if (meMarker != null) //meMarker is null if addMarkers fails.
+            {
+                map.animateCamera(CameraUpdateFactory.newLatLngZoom(
+                    LatLng(meMarker!!.position.latitude,
+                           meMarker!!.position.longitude), 14f))
+            }
+            else
+            {
+                map.animateCamera(CameraUpdateFactory.newLatLngZoom(
+                    LatLng(0.0, 0.0), 14f))
+            }
             map.uiSettings.isZoomControlsEnabled = true
             mapIsInitialized = true
         }
@@ -107,6 +117,7 @@ class MapsViewModel (private val locationRepository: LocationRepository,
         val marker = MarkerOptions()
             .position(loc)
             .title(title)
+            .flat(true) //This prevents the marker from rotating together with the map.
         if(marker.title == MainActivity.my_username)
             marker.icon(BitmapDescriptorFactory.fromResource(R.mipmap.arrow))
 


### PR DESCRIPTION
This implements the feature of starting the app at the users GPS location.
It also makes it so markers are not rotated when the map is.

Completes [this](https://trello.com/c/vmlMFCmM) and [this](https://trello.com/c/hQhenDW1) trello task.

**How to run**

1. Insert API key
2. Change current user in MainActivity to a valid one e.g. "bjarke"
3. Start the app

**Expected behavior**
1. Map should start at your GPS location
2. If map is rotated the markers should not rotate and meMarker should still be pointing in the direction you are heading.
